### PR TITLE
Rename print(), avoiding window.print

### DIFF
--- a/src/app/templates/main.jinja2
+++ b/src/app/templates/main.jinja2
@@ -228,7 +228,7 @@
                 </div>
             </div>
 
-            <button class="btn btn-primary btn-lg mb-3 btn-block" id="print" onclick="print()"><i class="mdi mdi-printer"></i> Print</button>
+            <button class="btn btn-primary btn-lg mb-3 btn-block" id="print" onclick="printLabel()"><i class="mdi mdi-printer"></i> Print</button>
 
             <div class="card">
                 <div class="card-header">

--- a/src/app/templates/main.js
+++ b/src/app/templates/main.js
@@ -227,7 +227,7 @@ function preview() {
     }, 300);
 }
 
-function print() {
+function printLabel() {
     $('#status').html('printing...').removeClass("alert-info alert-danger alert-warning alert-success alert-secondary").addClass("alert-info");
 
     if (get_mode() === "text") {


### PR DESCRIPTION
Yesterday, we discovered that on some browsers, print() opens the browser's print dialogue instead of printing the label. This is due to browsers now having [window.print()](https://developer.mozilla.org/en-US/docs/Web/API/Window/print), and some browsers (or browser versions) rather call that instead of the defined print() function.
I just renamed print() to printLabel() to avoid that conflict.